### PR TITLE
Adds check for volume creation status

### DIFF
--- a/raidformer.py
+++ b/raidformer.py
@@ -166,7 +166,7 @@ if (options.attach or options.snapshot) and not options.test:
             vol = ec2conn.create_volume(options.size, instance_data['placement']['availability-zone'])
         print "Created volume: ", vol.id
 
-        print "Waiting for {volume} to change to state available.".format(volume=vol.id)
+        print "Waiting for %s to change to state available" % vol.id
 
         ready = False
 
@@ -174,7 +174,7 @@ if (options.attach or options.snapshot) and not options.test:
             created = ec2conn.get_all_volumes([vol.id])[0]
             if created.status == "available":
                 ready = True
-                print "Volume {volume} is available".format(volume=vol.id)
+                print "Volume %s is available" % vol.id
 
         ec2conn.attach_volume(vol.id, instance_data['instance-id'], device)
         print "Attached volume: ", vol.id

--- a/raidformer.py
+++ b/raidformer.py
@@ -165,11 +165,19 @@ if (options.attach or options.snapshot) and not options.test:
             print "Creating new volume on device %s" % device
             vol = ec2conn.create_volume(options.size, instance_data['placement']['availability-zone'])
         print "Created volume: ", vol.id
+
+        ready = False
+
+        while not ready:
+            created = ec2conn.get_all_volumes([vol.id])[0]
+            if created.status == "available":
+                ready = True
+
         ec2conn.attach_volume(vol.id, instance_data['instance-id'], device)
         print "Attached volume: ", vol.id
         vol_ids.append(vol.id)
         vol.add_tag("Name", options.tag)
-    
+
     for device in attached_devices:
         found = False
     

--- a/raidformer.py
+++ b/raidformer.py
@@ -166,12 +166,15 @@ if (options.attach or options.snapshot) and not options.test:
             vol = ec2conn.create_volume(options.size, instance_data['placement']['availability-zone'])
         print "Created volume: ", vol.id
 
+        print "Waiting for {volume} to change to state available.".format(volume=vol.id)
+
         ready = False
 
         while not ready:
             created = ec2conn.get_all_volumes([vol.id])[0]
             if created.status == "available":
                 ready = True
+                print "Volume {volume} is available".format(volume=vol.id)
 
         ec2conn.attach_volume(vol.id, instance_data['instance-id'], device)
         print "Attached volume: ", vol.id


### PR DESCRIPTION
This pull ensures that newly created volumes are in the available status before attempting to attach them, which results in an error.

```
Traceback (most recent call last):
  File "./raidformer.py", line 168, in <module>
    ec2conn.attach_volume(vol.id, instance_data['instance-id'], device)
  File "/usr/lib/python2.7/dist-packages/boto/ec2/connection.py", line 1369, in attach_volume
    return self.get_status('AttachVolume', params, verb='POST')
  File "/usr/lib/python2.7/dist-packages/boto/connection.py", line 935, in get_status
    raise self.ResponseError(response.status, response.reason, body)
boto.exception.EC2ResponseError: EC2ResponseError: 400 Bad Request
<?xml version="1.0" encoding="UTF-8"?>
<Response><Errors><Error><Code>IncorrectState</Code><Message>vol-c92fa384 is not 'available'.</Message></Error></Errors><RequestID>97f9ecf4-1b41-4c58-8254-63fc725057c8</RequestID></Response>
```
